### PR TITLE
Draw dealer hand as well

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -254,6 +254,7 @@ Citizen.CreateThread(function()
 				DrawTimerBar(barCount, "SPLIT", handValue(splitHand))
 			end
 			DrawTimerBar(barCount, "HAND", handValue(hand))
+			DrawTimerBar(barCount, "DEALER", dealerValue[g_seat])
 		end
 
 		if _DEBUG == true then
@@ -385,6 +386,7 @@ function IsSeatOccupied(coords, radius)
 end
 
 dealerHand = {}
+dealerValue = {}
 dealerHandObjs = {}
 handObjs = {}
 
@@ -430,6 +432,7 @@ function CreatePeds()
 	for i,v in pairs(tables) do
 	
 		dealerHand[i] = {}
+		dealerValue[i] = {}
 		dealerHandObjs[i] = {}
 		local models = {
 			`s_f_y_casino_01`,
@@ -1227,6 +1230,11 @@ AddEventHandler("BLACKJACK:RetrieveCards", function(i, seat)
 			DeleteEntity(v)
 		end
 	end
+end)
+
+RegisterNetEvent("BLACKJACK:UpdateDealerHand")
+AddEventHandler("BLACKJACK:UpdateDealerHand", function(i, v)
+	dealerValue[i] = v
 end)
 	
 RegisterNetEvent("BLACKJACK:GiveCard")

--- a/server.lua
+++ b/server.lua
@@ -285,6 +285,8 @@ function StartTableThread(i)
 						local currentPlayers = {table.unpack(players[i])}
 						local deck = getDeck()
 						local dealerHand = {}
+						local dealerVisibleHand = {}
+						TriggerClientEvent("BLACKJACK:UpdateDealerHand", -1, index, handValue(dealerVisibleHand))
 						
 						currentPlayers = SortPlayers(currentPlayers)
 
@@ -304,8 +306,10 @@ function StartTableThread(i)
 							else
 								PlayDealerAnim(index, "anim_casino_b@amb@casino@games@blackjack@dealer", "female_deal_card_self_second_card")
 								DebugPrint("TABLE "..index..": DEALT DEALER "..card)
+								table.insert(dealerVisibleHand, card)
 							end
 							Wait(2000)
+							TriggerClientEvent("BLACKJACK:UpdateDealerHand", -1, index, handValue(dealerVisibleHand))
 
 							if #dealerHand > 1 then
 								PlayDealerSpeech(index, "MINIGAME_BJACK_DEALER_"..cardValue(dealerHand[2]))
@@ -341,9 +345,11 @@ function StartTableThread(i)
 						if handValue(dealerHand) == 21 then
 							DebugPrint("TABLE "..index..": DEALER HAS BLACKJACK")
 							PlayDealerAnim(index, "anim_casino_b@amb@casino@games@blackjack@dealer", "female_check_and_turn_card")
+							dealerVisibleHand = dealerHand
 							Wait(2000)
 							PlayDealerSpeech(index, "MINIGAME_BJACK_DEALER_BLACKJACK")
 							TriggerClientEvent("BLACKJACK:DealerTurnOverCard", -1, index)
+							TriggerClientEvent("BLACKJACK:UpdateDealerHand", -1, index, handValue(dealerVisibleHand))
 
 							for i,v in pairs(currentPlayers) do
 								TriggerClientEvent("BLACKJACK:GameEndReaction", v.player, "bad")
@@ -725,8 +731,10 @@ function StartTableThread(i)
 								PlayDealerAnim(index, "anim_casino_b@amb@casino@games@blackjack@dealer", "female_turn_card")
 								Wait(1000)
 								TriggerClientEvent("BLACKJACK:DealerTurnOverCard", -1, index)
+								dealerVisibleHand = dealerHand
 								Wait(1000)
 								PlayDealerSpeech(index, "MINIGAME_BJACK_DEALER_"..handValue(dealerHand))
+								TriggerClientEvent("BLACKJACK:UpdateDealerHand", -1, index, handValue(dealerVisibleHand))
 							end
 
 							if handValue(dealerHand) < 17 and ArePlayersStillIn(currentPlayers) then
@@ -740,6 +748,7 @@ function StartTableThread(i)
 									DebugPrint("TABLE "..index..": DEALT DEALER "..card)
 									Wait(2000)
 									PlayDealerSpeech(index, "MINIGAME_BJACK_DEALER_"..handValue(dealerHand))
+									TriggerClientEvent("BLACKJACK:UpdateDealerHand", -1, index, handValue(dealerVisibleHand))
 								until handValue(dealerHand) >= 17
 							end
 						end


### PR DESCRIPTION
Hi there, I made it so that the dealer hand value draws in a bar as well. Just like the players hand value already does. Shows up at the same time as the players hand value. The server sends the current value of the dealer hand, but the array used does not have the hidden card. This card gets added once the dealer flips it over.

![image](https://user-images.githubusercontent.com/40723838/117989211-6a6efb80-b33c-11eb-946f-d08a68e0dcc9.png)
This is a screenshot of the dealer having a 2, and the bar also showing a 2.